### PR TITLE
PCA: k≤d instead of k<d

### DIFF
--- a/smd_pca.ipynb
+++ b/smd_pca.ipynb
@@ -906,7 +906,7 @@
     "\n",
     "Die Hauptkomponentenanalyse sucht nach einer Basis im Raum indem die Varianz entlang der Basisvektoren maximiert wird.\n",
     "\n",
-    "Gegeben seien also $N$ Datenpunkte mit $d$ Dimensionen die auf $k < d$ Dimensionen transformiert werden sollen.\n",
+    "Gegeben seien also $N$ Datenpunkte mit $d$ Dimensionen, die auf $k \\leq d$ Dimensionen transformiert werden sollen.\n",
     "\n",
     "Dazu wird der Raum in eine neue Basis transformiert. Es werden also eventuell mehrere Dimensionen/Attribute zu einer neuen zusammengefasst.  \n",
     "\n",


### PR DESCRIPTION
Für das letzte Übungsblatt sollte eine PCA durchgeführt werden, jedoch ohne die Dimensionalität zu verringern. 
Nicht nur meine Abgabegruppe hat sich davon verwirren lassen, dass in der Vorlesung explizit von `k<d` statt `k≤d` die Rede war. 