### PR TITLE
Fix env name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ $ conda env create -f environment.yml
 ```
 
 This will create a new conda environment with all needed packages for these lectures
-named `ml-lecture`.
+named `ml`.
 
 To use this environment, run
 ```
-$ conda activate ml-lecture
+$ conda activate ml
 ```
 everytime before you start working on these lectures.
 


### PR DESCRIPTION
Minor change in the README. Environment name was changed from `ml-lecture` to `ml`, instructions in README continued to use the old name. 